### PR TITLE
Updated grammar "infromation" to "information"

### DIFF
--- a/articles/active-directory/manage-apps/application-proxy-connectors.md
+++ b/articles/active-directory/manage-apps/application-proxy-connectors.md
@@ -20,7 +20,7 @@ Connectors are what make Azure AD Application Proxy possible. They're simple, ea
 
 ## What is an Application Proxy connector?
 
-Connectors are lightweight agents that sit on-premises and facilitate the outbound connection to the Application Proxy service. Connectors must be installed on a Windows Server that has access to the backend application. You can organize connectors into connector groups, with each group handling traffic to specific applications. For more infromation on Application proxy and a diagrammatic representation of application proxy architecture see [Using Azure AD Application Proxy to publish on-premises apps for remote users](what-is-application-proxy.md#application-proxy-connectors)
+Connectors are lightweight agents that sit on-premises and facilitate the outbound connection to the Application Proxy service. Connectors must be installed on a Windows Server that has access to the backend application. You can organize connectors into connector groups, with each group handling traffic to specific applications. For more information on Application proxy and a diagrammatic representation of application proxy architecture see [Using Azure AD Application Proxy to publish on-premises apps for remote users](what-is-application-proxy.md#application-proxy-connectors)
 
 ## Requirements and deployment
 


### PR DESCRIPTION
Under the section "What is an Application Proxy connector?" the word information is misspelled.